### PR TITLE
Satisfiy audit-argument-checks for server-side eventsOnLoggedOut method

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,6 +35,8 @@ Meteor.methods({
         Hooks.onLoggedIn(this.userId);
     },
     eventsOnLoggedOut: function (userId) {
+	// Check argument to server-side method
+	check(userId, String);
         // Fire the loggedOut event
         Hooks.onLoggedOut(userId);
     }


### PR DESCRIPTION
Apps with the audit-argument-checks package installed throw an exception when calling the eventsOnLoggedOut server-side method. Adding this argument check quiets this exception (and is probably good practice anyway).
